### PR TITLE
bump scssphp to fix php 7.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.3.0",
         "oyejorge/less.php": "1.7.*",
-        "leafo/scssphp": "0.6.*"
+        "leafo/scssphp": "0.7.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
scssphp 0.6 uses the deprecated "each" function.
The 0.7.* releases fixed this.